### PR TITLE
Fix Traefik Port Mapping Issues with Next.js by Using nginx as Reverse Proxy

### DIFF
--- a/reverse-proxy/traefik/docker-compose.traefik.yml
+++ b/reverse-proxy/traefik/docker-compose.traefik.yml
@@ -1,8 +1,15 @@
 version: "3.3"
 services:
   rallly:
+    hostname: rallly
+  rallly_nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    restart: always
     labels:
       traefik.enable: "true"
-      traefik.http.routers.rallly.rule: "Host(`example.com`)" # change to your domain name
-      traefik.http.routers.rallly.entrypoints: "websecure"
-      traefik.http.services.rallly.loadbalancer.server.port: "3000"
+      traefik.http.routers.rallly.entrypoints: websecure
+      traefik.http.routers.rallly.rule: Host(`example.com`)
+      traefik.http.routers.rallly.service: rallly
+      traefik.http.services.rallly.loadbalancer.server.port: "80"

--- a/reverse-proxy/traefik/nginx.conf
+++ b/reverse-proxy/traefik/nginx.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+  listen [::]:80;
+
+  location / {
+    proxy_pass http://rallly:3000;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}


### PR DESCRIPTION
This Pull Request addresses an issue with port mapping when using Traefik with Next.js. After rigorous testing on multiple systems, it has been observed that Traefik has difficulties in successfully mapping the Next.js port directly.

This PR introduces nginx as a reverse proxy for Rallly, thereby resolving the port mapping issues when using Traefik.