### PR TITLE
Remove hardcoded Postgres 14 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ HTTP/HTTPS ──────►│   Traefik    │ (ports 80/443, auto HTTPS)
                   ▼           ▼
                ┌──────┐   ┌──────┐
                │  DB  │   │Garage│
-               │(PG14)│   │ (S3) │
+               │ (PG) │   │ (S3) │
                └──────┘   └──────┘
 ```
 
 - **Traefik** — Reverse proxy with automatic HTTPS via Let's Encrypt
 - **Rallly** — The web application (sessions are stored in Postgres; rate limiting is in-memory)
-- **PostgreSQL 14** — Database
+- **PostgreSQL** — Database (18 on fresh installs; existing installs stay pinned to their current major via `POSTGRES_VERSION`)
 - **Garage** — S3-compatible object storage for file uploads (internal only, proxied through the app)
 
 Only Traefik binds to host ports. All other services are isolated on the Docker network.


### PR DESCRIPTION
Follow-up to #35: the README's architecture section still said the bundled database is PostgreSQL 14. The diagram label is now version-neutral, and the component list explains the actual behavior — 18 on fresh installs, existing installs pinned to their current major via `POSTGRES_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture documentation to use a generic PostgreSQL label in the diagram.
  * Clarified that fresh installs use PostgreSQL 18, while existing installs remain on their current version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->